### PR TITLE
update `pkginfo` to version `1.8.3`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pkginfo" %}
-{% set version = "1.8.2" %}
+{% set version = "1.8.3" %}
 {% set hash_type = "sha256" %}
 {% set hash_value = "e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd" %}
 
@@ -9,23 +9,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pkginfo/pkginfo-{{ version }}.tar.gz
-  sha256: 542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff
+  sha256: a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c
 
 build:
-  noarch: python
   number: 0
+  skip: True  # [py<36]
   entry_points:
     - pkginfo = pkginfo.commandline:main
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
@@ -47,7 +47,7 @@ about:
     This package provides an API for querying the distutils metadata written in
     the ``PKG-INFO`` file inside a source distriubtion (an ``sdist``) or
     a binary distribution (e.g., created by running ``bdist_egg``)
-  doc_url: http://pythonhosted.org/pkginfo/
+  doc_url: https://pythonhosted.org/pkginfo/
   dev_url: https://code.launchpad.net/~tseaver/pkginfo/trunk
 
 extra:


### PR DESCRIPTION

  `pkginfo` version `1.8.3`
1. - [x] Check the upstream
    https://bazaar.launchpad.net/~rafadurancastaneda/pkginfo/trunk/files
2. - [X] Check the pinnings
3. - [x] Check the changelogs
    https://bazaar.launchpad.net/~rafadurancastaneda/pkginfo/trunk/view/head:/CHANGES.txt

    There are no significant breaking changes mentioned in the changelog

4. - [x] Additional research
    https://github.com/conda-forge/pkginfo-feedstock/issues

    there are currently no open issues mentioned at the time of the review.

5. - [x] Verify the `dev_url`
    https://code.launchpad.net/~tseaver/pkginfo/trunk
6. - [x] Verify the `doc_url`
    https://pythonhosted.org/pkginfo/
7. - [x] License is `spdx` compliant
    MIT
8. - [x] License family is present
    MIT
9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    setuptools
11. - [x] Verify if the package needs `wheel`
    wheel
12. - [x] `pip` in the test section
    pip
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Verify that private modules are not mentioned on the recipe For example: (_private_module)

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `pkginfo` to version `1.8.3`
