### PR TITLE
Update 1.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "pkginfo" %}
-{% set version = "1.9.6" %}
-{% set hash_type = "sha256" %}
-{% set hash_value = "e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd" %}
+{% set version = "1.10.0" %}
 
 package:
   name: '{{ name|lower }}'
@@ -9,14 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pkginfo/pkginfo-{{ version }}.tar.gz
-  sha256: 8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046
+  sha256: 5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297
 
 build:
   number: 0
   skip: True  # [py<38]
   entry_points:
     - pkginfo = pkginfo.commandline:main
-  script: {{ PYTHON }} -m pip install --no-deps . -vv
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:


### PR DESCRIPTION
[pkginfo-feedstock](https://github.com/AnacondaRecipes/pkginfo-feedstock) 1.10.0

**Destination channel:** defaults

### Links

- [PKG-4800](https://anaconda.atlassian.net/browse/PKG-4800) 
- [Upstream repository](https://bazaar.launchpad.net/~tseaver/pkginfo/trunk/files)
- [Upstream changelog/diff](https://bazaar.launchpad.net/~tseaver/pkginfo/trunk/revision/235)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- version, sha, and `--no-build-isolation`


[PKG-4800]: https://anaconda.atlassian.net/browse/PKG-4800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ